### PR TITLE
Update README.rst install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Installation
 ------------
 Use pip_ like::
 
-    $ pip install "django-permissions>=0.5.0"
+    $ pip install "django-permission>=0.5.0"
 
 .. _pip:  https://pypi.python.org/pypi/pip
 


### PR DESCRIPTION
When I run pip install "django-permissions>=0.5.0" on my system (OS X 10.9.2), it pulls in a different python package: django-permissions 1.0.3 by kai.diefenbach@iqpp.de. If I run pip install "django-permission>=0.5.0", I pull in the correct package
