### PR TITLE
Use LooseVersion instead of StrictVersion refs #24

### DIFF
--- a/src/permission/templatetags/patch.py
+++ b/src/permission/templatetags/patch.py
@@ -2,10 +2,10 @@
 """
 django if templatetag patch
 """
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 from django import get_version
 
-if StrictVersion(get_version()) < '1.4':
+if LooseVersion(get_version()) < '1.4':
     from django.template import Node
     from django.template import NodeList
     from django.template import VariableDoesNotExist


### PR DESCRIPTION
I use `LooseVersion` to prevent errors when it is used on django beta version.

See more detail #24
