### PR TITLE
Fix import of `six` module

### DIFF
--- a/src/permission/utils/permissions.py
+++ b/src/permission/utils/permissions.py
@@ -6,7 +6,7 @@ In this module, term *perm* indicate the identifier string permission written
 in 'app_label.codename' format.
 """
 from __future__ import unicode_literals
-from django.utils.six import string_types
+from permission.compat import six
 
 
 def get_perm_codename(perm, fail_silently=True):


### PR DESCRIPTION
Django 3.0 doesn't have django.utils.six anymore, there was already a
fix for that, but it wasn't being used in the file
src/permission/utils/permissions.py. I'm just making this file use the
same way to import the six module.